### PR TITLE
Muted COMException when creating MCX gate on WINDOWS 11

### DIFF
--- a/QuIDE/QuIDE.csproj
+++ b/QuIDE/QuIDE.csproj
@@ -32,20 +32,20 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.9" />
+        <PackageReference Include="Avalonia" Version="11.0.10" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.9" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.9" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.10" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.9" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.9" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.6" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
         <PackageReference Include="DotNet.Bundle" Version="0.9.13" />
         <PackageReference Include="MessageBox.Avalonia" Version="3.1.5.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/QuIDE/Views/Controls/CircuitGrid.axaml.cs
+++ b/QuIDE/Views/Controls/CircuitGrid.axaml.cs
@@ -1,11 +1,13 @@
 ﻿#region
 
 using System;
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Media;
+using QuIDE.CodeHelpers;
 using QuIDE.QuantumModel;
 using QuIDE.ViewModels;
 using QuIDE.ViewModels.Controls;
@@ -93,7 +95,16 @@ public partial class CircuitGrid : UserControl
         var dragData = new DataObject();
         dragData.Set(typeof(Tuple<int, RegisterRefModel>).ToString(), data);
 
-        DragDrop.DoDragDrop(e, dragData, DragDropEffects.Link);
+        try
+        {
+            DragDrop.DoDragDrop(e, dragData,DragDropEffects.Link);
+        }
+        catch (COMException exception)
+        {
+            var msg = exception.Message;
+            Console.WriteLine(exception);
+            // SimpleDialogHandler.ShowSimpleMessage(msg);
+        }
     }
 
     private void ctrlPoint_Drop(object sender, PointerEventArgs pointerEventArgs)


### PR DESCRIPTION
- on my machine (WINDOWS 11), creating a MCX gate results in a COMException when executing the DoDragDrop() method, which was thrown somewhere in the Avalonia.Win32 backend and ultimately crashes QuIDE
-> its unclear what is actually the cause, but in any case, just catching the exception still results in a successful MCX creation
-> as an attempt to fix this, i also updated all packages, but it still throws ... 
NOTE: the creation of MCX gates is still unreliable and often only succeeds after some attempts, but at least the app doesnt crash now :)

- also fixed the indentation for codegen of extensions, reordered some methods in the Codegenerator